### PR TITLE
Enable Rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ desktop.ini
 upload.py
 vendor/
 includes/mail_auth.php
+includes/salt.php

--- a/cron.php
+++ b/cron.php
@@ -1,0 +1,15 @@
+#!/usr/bin/env php
+<?php
+
+include_once "./includes/db.php";
+
+// Create connection
+$conn = new mysqli($servername, $username, $password, $DBName);
+
+// Check connection
+if ($conn->connect_error) {
+    die("Connection failed: " . $conn->connect_error);
+}
+
+$sqlquery = "DELETE FROM `hits` where `date` < (CURRENT_TIMESTAMP - 18000)";
+$result = $conn->query($sqlquery);

--- a/includes/components/get.php
+++ b/includes/components/get.php
@@ -1,8 +1,12 @@
 <?php
 
-  include_once "./db.php";
+include_once "./db.php";
+include_once "./components/rate.php";
 
 if (isset($user_code)) {
+
+  noteLimit("get");
+
   // Create connection
   $conn = new mysqli($servername, $username, $password, $DBName);
 

--- a/includes/components/new.php
+++ b/includes/components/new.php
@@ -1,6 +1,9 @@
 <?php
 
 include_once "./db.php";
+include_once "./components/rate.php";
+
+noteLimit("set");
 
 // Create connection
 $conn = new mysqli($servername, $username, $password, $DBName);
@@ -21,7 +24,6 @@ function gen_uid($len = 10)
 }
 
 $usr = gen_uid(5);
-$timestamp = date("Y-m-d H:i:s");
 
 $sqlquery = "SELECT * FROM userurl WHERE url = '$url'";
 $result = $conn->query($sqlquery);
@@ -43,7 +45,7 @@ if ($result->num_rows > 0) {
         $duplicateCodeResult = $conn->query($duplicateCodeQuery);
     }
 
-    $sqlquery = "INSERT INTO userurl (id, usr, url, date) VALUES (NULL, '$usr', '$url', '$timestamp') ";
+    $sqlquery = "INSERT INTO userurl (id, usr, url, date) VALUES (NULL, '$usr', '$url', NOW()) ";
     if ($conn->query($sqlquery) === FALSE) {
         echo "Error: " . $sqlquery . "<br>" . $conn->error;
     }

--- a/includes/components/rate.php
+++ b/includes/components/rate.php
@@ -42,8 +42,8 @@ function noteLimit($action) {
     }
     
     if($count > 15) {
-        die("Rate Limited");
         http_response_code(429);
+        die("Rate Limited");
     }
 
     $sqlquery = "INSERT INTO hits (id, iphash, date, operation) VALUES (NULL, '$cryptIP', NOW(), '$action') ";

--- a/includes/components/rate.php
+++ b/includes/components/rate.php
@@ -1,12 +1,15 @@
 <?php
 
+include_once "./db.php";
+include_once "./salt.php";
+
 $GLOBALS['servername'] = $servername;
 $GLOBALS['username'] = $username;
 $GLOBALS['password'] = $password;
 $GLOBALS['dbname'] = $DBName;
+$GLOBALS['salt'] = $salt;
 
 function noteLimit($action) {
-    include_once "./db.php";
     
     //whether ip is from share internet
     if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
@@ -21,7 +24,7 @@ function noteLimit($action) {
         $ip = $_SERVER['REMOTE_ADDR'];
     }
 
-    $cryptIP = hash("sha512", $ip);
+    $cryptIP = hash("sha512", $GLOBALS['salt']."-".$ip);
 
     // Create connection
     $conn = new mysqli($GLOBALS['servername'], $GLOBALS['username'], $GLOBALS['password'], $GLOBALS['dbname']);

--- a/includes/components/rate.php
+++ b/includes/components/rate.php
@@ -34,7 +34,7 @@ function noteLimit($action) {
         die("Connection failed: " . $conn->connect_error);
     }
 
-    $rateLimitCheck = "SELECT COUNT(*) FROM `hits` where `date` > (CURRENT_TIMESTAMP - 3600) AND `iphash` = '$cryptIP'";
+    $rateLimitCheck = "SELECT COUNT(*) FROM `hits` where `date` > (CURRENT_TIMESTAMP - 60) AND `iphash` = '$cryptIP'";
     $rateLimitCheckResult = $conn->query($rateLimitCheck);
     while ($row = $rateLimitCheckResult->fetch_assoc()) {
         $count = $row["COUNT(*)"];

--- a/includes/components/rate.php
+++ b/includes/components/rate.php
@@ -1,0 +1,50 @@
+<?php
+
+$GLOBALS['servername'] = $servername;
+$GLOBALS['username'] = $username;
+$GLOBALS['password'] = $password;
+$GLOBALS['dbname'] = $DBName;
+
+function noteLimit($action) {
+    include_once "./db.php";
+    
+    //whether ip is from share internet
+    if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
+        $ip = $_SERVER['HTTP_CLIENT_IP'];
+    }
+    //whether ip is from proxy
+    elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    }
+    //whether ip is from remote address
+    else {
+        $ip = $_SERVER['REMOTE_ADDR'];
+    }
+
+    $cryptIP = hash("sha512", $ip);
+
+    // Create connection
+    $conn = new mysqli($GLOBALS['servername'], $GLOBALS['username'], $GLOBALS['password'], $GLOBALS['dbname']);
+
+    // Check connection
+    if ($conn->connect_error) {
+        die("Connection failed: " . $conn->connect_error);
+    }
+
+    $rateLimitCheck = "SELECT COUNT(*) FROM `hits` where `date` > (CURRENT_TIMESTAMP - 3600) AND `iphash` = '$cryptIP'";
+    $rateLimitCheckResult = $conn->query($rateLimitCheck);
+    while ($row = $rateLimitCheckResult->fetch_assoc()) {
+        $count = $row["COUNT(*)"];
+        break;
+    }
+    
+    if($count > 15) {
+        die("Rate Limited");
+    }
+
+    $sqlquery = "INSERT INTO hits (id, iphash, date, operation) VALUES (NULL, '$cryptIP', NOW(), '$action') ";
+    $result = $conn->query($sqlquery);
+    if ($result === FALSE) {
+        echo "Error: " . $sqlquery . "<br>" . $conn->error;
+    }
+}

--- a/includes/components/rate.php
+++ b/includes/components/rate.php
@@ -43,6 +43,7 @@ function noteLimit($action) {
     
     if($count > 15) {
         die("Rate Limited");
+        http_response_code(429);
     }
 
     $sqlquery = "INSERT INTO hits (id, iphash, date, operation) VALUES (NULL, '$cryptIP', NOW(), '$action') ";

--- a/includes/get.php
+++ b/includes/get.php
@@ -9,7 +9,7 @@ include_once "menu.php";
 if (!empty($_POST['user'])) {
   $user_code = $_POST['user'];
 
-  include_once ". /db.php";
+  include_once "./db.php";
   include_once "components/get.php";
 }
 if (!empty($url)) {


### PR DESCRIPTION
A demo version of rate-limiting on Interclip.
* the user either uses the get or set API
* this call and the shasha512 hash of the IP are stored in the database
* a check is made that returns the number of request for the last hour
* if that number > 15, `die()`