### PR TITLE
feat: Redesigned rate limiting with Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 public/upload/uploads/
 includes/size.json
 .env
+dump.rdb

--- a/includes/components/get.php
+++ b/includes/components/get.php
@@ -5,7 +5,7 @@ include_once "includes/components/redis.php";
 
 if (isset($user_code)) {
 
-  noteLimit("get");
+  noteLimit();
 
   // Get the cached value (if it exists)
   $cached = getRedis($user_code);

--- a/includes/components/new.php
+++ b/includes/components/new.php
@@ -12,7 +12,7 @@ include_once "includes/components/redis.php";
  */
 function createClip($url)
 {
-    noteLimit("set");
+    noteLimit();
 
     $err = "";
 

--- a/includes/components/rate.php
+++ b/includes/components/rate.php
@@ -1,47 +1,30 @@
 <?php
 
-function noteLimit($action) {
-    
-    //whether ip is from share internet
+include_once "./redis.php";
+
+function noteLimit()
+{
+
+    // The IP is from the shared internet
     if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
         $ip = $_SERVER['HTTP_CLIENT_IP'];
     }
-    //whether ip is from proxy
+    // The IP is from a proxy
     elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
         $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
     }
-    //whether ip is from remote address
+    // The IP is from a remote address
     else {
         $ip = $_SERVER['REMOTE_ADDR'];
     }
 
-    $cryptIP = hash("sha512", $_ENV['SALT']."-".$ip);
+    $cryptIP = hash("sha512", $_ENV['SALT'] . "-" . $ip);
 
-    // Create connection
-    $conn = new mysqli($_ENV['DB_SERVER'], $_ENV['USERNAME'], $_ENV['PASSWORD'], $_ENV['DB_NAME']);
+    $count = ipHit($cryptIP);
 
-    // Check connection
-    if ($conn->connect_error) {
-        die("Connection failed: " . $conn->connect_error);
-    }
-
-    $rateLimitCheck = "SELECT COUNT(*) FROM `hits` where `date` > (CURRENT_TIMESTAMP - 60) AND `iphash` = '$cryptIP'";
-    $rateLimitCheckResult = $conn->query($rateLimitCheck);
-    while ($row = $rateLimitCheckResult->fetch_assoc()) {
-        $count = $row["COUNT(*)"];
-        break;
-    }
-    
-    if($count > 15) {
+    if ($count > 15) {
         http_response_code(429);
         die("Rate Limited");
-    }
-
-    $sqlquery = "INSERT INTO hits (id, iphash, date, operation) VALUES (NULL, '$cryptIP', NOW(), '$action') ";
-    $result = $conn->query($sqlquery);
-    if ($result === FALSE) {
-        echo "Error: " . $sqlquery . "<br>" . $conn->error;
-        return false;
     }
 
     return true;

--- a/includes/components/redis.php
+++ b/includes/components/redis.php
@@ -10,6 +10,22 @@ try {
     $GLOBALS["redisAvailable"] = false; // Failed connecting to the server
 }
 
+function ipHit($hashedIP)
+{
+    if ($GLOBALS["redisAvailable"] && $GLOBALS["redis"]->ping()) {
+
+        $redisKey = "ip-".substr($hashedIP, 0, 7);
+
+        $GLOBALS["redis"]->incr($redisKey);
+        $GLOBALS["redis"]->expire($redisKey, 30);
+        $count = $GLOBALS["redis"]->get($redisKey);
+
+        return $count;
+    } else {
+        return 0;
+    }
+}
+
 function storeRedis($key, $value)
 {
 


### PR DESCRIPTION
The current rate limiter I have made sucks, as it queries the MySQL database on every request. That's just very inefficient! Redis only keeps tab on the number of hits per IP (hashed IP, to be specific, and only the first 7 characters) and that means that within 30 seconds of the last request, there is no trace of the client, yay, privacy!