### PR TITLE
fix: mocked accounts

### DIFF
--- a/includes/components/html/adminbar.php
+++ b/includes/components/html/adminbar.php
@@ -57,7 +57,7 @@ $currBranch = $branches["current"];
     <span class="lg">PHP <?php echo phpversion(); ?></span>
     <span class="lg">Memory: <?php echo formatBytes(memory_get_usage()) ?></span>
     <span class="ending lg">
-      Hi, <?php echo $user["name"] ? $user['name'] : $user["nickname"]  ?>
+      Hi, <?php echo $user["name"] ?? $user["nickname"]  ?>
       <a class="subitem" href="<?php echo ROOT ?>/logout">Log out</a>
     </span>
   </div>


### PR DESCRIPTION
This PR fixes the mocked accounts issue. The issue boils down to that we cannot use an expression with a non-existing array value. Changed the expression to use null coalescing instead. 👍