### PR TITLE
Fix code-based URL redirects (e.g. /iclip)

### DIFF
--- a/router.php
+++ b/router.php
@@ -95,7 +95,7 @@ SimpleRouter::group(['prefix' => ROOT], function () {
 
     // Match clip codes
     SimpleRouter::all(
-        '/code',
+        '/{user_code}',
         function ($user_code) {
             include_once "includes/components/get.php";
             if (isset($url)) {
@@ -105,7 +105,7 @@ SimpleRouter::group(['prefix' => ROOT], function () {
                 include_once "includes/error.php";
             }
         }
-    )->setMatch('/^\/([a-zA-Z0-9]){5}\/?$/');
+    )->where(['user_code' => '[a-zA-Z0-9]{5}']);
 
     /* Internal behavior */
 

--- a/router.php
+++ b/router.php
@@ -97,6 +97,7 @@ SimpleRouter::group(['prefix' => ROOT], function () {
     SimpleRouter::all(
         '/{user_code}',
         function ($user_code) {
+            include_once "includes/lib/functions.php";
             include_once "includes/components/get.php";
             if (isset($url)) {
                 reDir($url);


### PR DESCRIPTION
## Description

Code-based short URLs (e.g. `/iclip`) were returning a 200 error page instead of redirecting to the stored URL.

The `setMatch` regex approach with a dummy `/code` URL pattern was broken — SimpleRouter's `parseParameters` overwrites regex-captured params with an empty array when the URL pattern doesn't match the actual URL, so `$user_code` was never passed to the callback. Additionally, `reDir()` was called without including `functions.php` where it's defined.

Replaced with a named `{user_code}` parameter and a `where` constraint, and added the missing include.

## Related Issue(s)

N/A

## How to test

1. Create a clip via the `/set` flow
2. Visit the 5-character code directly as a URL path (e.g. `/u6pir`)
3. Verify it redirects to the stored URL instead of showing a 404 error page