### PR TITLE
Harden production deployment guardrails

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 0 1 * 1"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze
@@ -20,18 +24,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
         with:
           languages: ${{ matrix.language }}
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,42 +1,50 @@
 name: Deploy Interclip
+permissions:
+  contents: read
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
 on:
-  push:
-    branches:
-      - main
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      rollout_ready:
+        description: Confirm backup restore, schema migration, Redis cutover, secrets, trusted proxies, and origin TLS are ready
+        required: true
+        type: boolean
 
 jobs:
   deploy-production:
-      name: Deploy to production
-      runs-on: ubuntu-latest
-      steps:
-        - name: Tailscale
-          uses: tailscale/github-action@v2
-          with:
-            oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-            oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-            tags: tag:interclip
-        - name: Deploy via SSH
-          run: |
-            ssh ${{ secrets.USERNAME }}@${{ secrets.HOST }} "cd /var/www/interclip && git pull --all && sudo -u www-data composer install && yarn && yarn build"
+    if: inputs.rollout_ready == true
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Tailscale
+        uses: tailscale/github-action@4e4c49acaa9818630ce0bd7a564372c17e33fb4d # v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:interclip
+      - name: Deploy via SSH
+        run: |
+          ssh ${{ secrets.USERNAME }}@${{ secrets.HOST }} "cd /var/www/interclip && git pull --ff-only origin main && sudo -u www-data composer install --no-dev --classmap-authoritative --no-interaction --no-scripts && yarn install --frozen-lockfile --production=false && yarn build && rm -rf node_modules"
 
   purge-cache:
     name: Purge Cloudflare cache
     needs: [deploy-production]
-    if: always()
+    if: needs.deploy-production.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Setup Deno
-        uses: denolib/setup-deno@v2
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
         with:
           deno-version: v1.x
       - name: Purge Cloudflare cache
-        run: deno run --allow-net --allow-env --allow-run scripts/cachePurge.ts
+        run: deno run --allow-net=api.cloudflare.com --allow-env=CLOUDFLARE_ZONE_ID,CLOUDFLARE_API_KEY scripts/cachePurge.ts
         env:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE }}
           CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_TOKEN }}
@@ -46,9 +54,9 @@ jobs:
     needs: purge-cache
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Audit URLs using Lighthouse
-        uses: treosh/lighthouse-ci-action@10.1.0
+        uses: treosh/lighthouse-ci-action@03becbfc543944dd6e7534f7ff768abb8a296826 # 10.1.0
         with:
           urls: |
             https://interclip.app/
@@ -60,4 +68,3 @@ jobs:
           budgetPath: ./budget.json # test performance budgets
           uploadArtifacts: true # save results as an action artifacts
           temporaryPublicStorage: true # upload lighthouse report to the temporary storage
-

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,5 +1,5 @@
 Contact: mailto:filip.tronicek@seznam.cz
-Expires: Sun, 9 Mar 2025 00:00 +0200
+Expires: 2027-07-10T22:00:00Z
 Acknowledgments: https://github.com/interclip/interclip/wiki/Security-hall-of-fame
 Preferred-Languages: en, de, cs
 Canonical: https://interclip.app/.well-known/security.txt

--- a/scripts/cachePurge.ts
+++ b/scripts/cachePurge.ts
@@ -1,68 +1,26 @@
-import { exec } from "https://deno.land/x/execute/mod.ts";
-
 const CLOUDFLARE_API_KEY = Deno.env.get("CLOUDFLARE_API_KEY");
 const CLOUDFLARE_ZONE_ID = Deno.env.get("CLOUDFLARE_ZONE_ID");
-const CLOUDFLARE_DOMAIN = "interclip.app";
 
-// Get the list of changed files from git
-exec("git diff HEAD~1 --name-only").then((output: string) => {
-  // Split the output into an array of file names
-  const changedFiles = output.split("\n").filter((f) => f);
+if (!CLOUDFLARE_API_KEY || !CLOUDFLARE_ZONE_ID) {
+  throw new Error("Cloudflare cache purge credentials are not configured");
+}
 
-  if (changedFiles.length === 0) {
-    console.log("No files changed, skipping cache purge");
-    return;
-  }
+const response = await fetch(
+  `https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache`,
+  {
+    headers: {
+      Authorization: `Bearer ${CLOUDFLARE_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ purge_everything: true }),
+    method: "POST",
+  },
+);
 
-  const skipFiles = [
-    "README.md",
-    "LICENSE",
-    "package.json",
-    "package-lock.json",
-    "tsconfig.json",
-    "scripts/",
-    ".github/",
-    ".gitignore",
-    ".gitpod.yml",
-    "gitpod.Dockerfile",
-    "apache.conf",
-    ".vscode/",
-    ".git/",
-  ];
+if (!response.ok) {
+  throw new Error(
+    `Failed to purge the Cloudflare cache (HTTP ${response.status}): ${await response.text()}`,
+  );
+}
 
-  // Filter out files that we don't want to purge
-  const filesToPurge = changedFiles.filter((f) => {
-    return !skipFiles.some((g) => f.startsWith(g));
-  });
-
-  if (filesToPurge.some((f) => f.endsWith(".ts"))) {
-    console.log("Typescript files changed, purging all js files");
-    filesToPurge.push("*.js");
-  }
-
-  // Purge the cache for each changed file
-  filesToPurge.forEach((file: string) => {
-    const fileUrl = new URL(`https://${CLOUDFLARE_DOMAIN}`);
-    fileUrl.pathname = file;
-
-    console.log(`Purging cache for ${fileUrl}`);
-    fetch(
-      `https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache`,
-      {
-        headers: {
-          Authorization: `Bearer ${CLOUDFLARE_API_KEY}`,
-        },
-        body: JSON.stringify({ files: [fileUrl] }),
-        method: "DELETE",
-      }
-    ).then((response) => {
-      if (response.ok) {
-        console.log(`Purged cache for ${file}`);
-      } else {
-        console.error(
-          `Failed to purge cache for ${file} (HTTP ${response.status})`
-        );
-      }
-    });
-  });
-});
+console.log("Purged the Cloudflare zone cache");


### PR DESCRIPTION
## Summary

- require an explicit, protected production deployment dispatch
- serialize production deployments and only purge caches after a successful deploy
- pin third-party GitHub Actions and reduce workflow token permissions
- replace the command-executing cache purge with one scoped Cloudflare API request
- refresh the published security contact expiry

## Rollout impact

Merging this PR disables automatic production deployment from pushes and releases. Production deploys must be started manually with the rollout checklist acknowledged.

This is the first PR in a three-part stack:

1. #431 — deployment guardrails
2. #432 — security hardening
3. #433 — dev container and smoke tests

## Validation

- Prettier check
- `git diff --check`
