### PR TITLE
Honor forwarded HTTPS in Apache

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,6 +18,7 @@
 
     RewriteCond %{HTTP_HOST} ^interclip\.app(?::[0-9]+)?$ [NC]
     RewriteCond %{HTTPS} !=on
+    RewriteCond %{HTTP:X-Forwarded-Proto} !^https$ [NC]
     RewriteRule ^ https://interclip.app%{REQUEST_URI} [R=308,L]
 
     # Only the front controller and built/static assets are web-accessible.

--- a/tests/Unit/SecurityControlTest.php
+++ b/tests/Unit/SecurityControlTest.php
@@ -107,6 +107,7 @@ it('keeps public controllers and dependency metadata outside direct HTTP access'
         ->and($accessRules)->toContain('css/.*|img/.*|out/.*')
         ->and($accessRules)->toContain('composer\\.(?:json|lock)')
         ->and($accessRules)->toContain('RewriteRule ^ router.php [END,QSA]')
+        ->and($accessRules)->toContain('RewriteCond %{HTTP:X-Forwarded-Proto} !^https$ [NC]')
         ->and($accessRules)->not()->toContain('Header set Access-Control-Allow-Origin');
 });
 


### PR DESCRIPTION
## Summary

- avoid the canonical HTTPS redirect when the TLS-terminating proxy already supplied `X-Forwarded-Proto: https`
- retain the existing redirect for direct HTTP requests
- assert the proxy condition in the security control suite

## Root cause

Apache receives plain HTTP from the loopback-only reverse proxy. The canonical redirect checked only Apache's local TLS state, so an external HTTPS request was redirected back to itself indefinitely before PHP could apply its trusted-proxy validation.

## Impact

Production HTTPS requests reach the application normally while direct HTTP requests still receive the canonical `308` upgrade. PHP continues to accept forwarded HTTPS only when `REMOTE_ADDR` matches `TRUSTED_PROXIES`.

## Validation

- `vendor/bin/pest` — 50 tests, 281 assertions
- `git diff --check`
- production direct proxy request with `X-Forwarded-Proto: https` — `200`
- production public request with redirects enabled — `200`
- in-app browser homepage, clip retrieval, case-insensitive retrieval, and Auth0 login redirect smoke tests
