### PR TITLE
Restore the historical total clips fact

### DIFF
--- a/public/about.php
+++ b/public/about.php
@@ -5,7 +5,7 @@ require_once ROOT_DIR . '/includes/lib/database.php';
 
 $release = trim((string) ($_ENV['APP_RELEASE'] ?? ''));
 $count = null;
-$cachedCount = getRedis('active-clip-count-v1');
+$cachedCount = getRedis('total-clip-count-v1');
 if (is_string($cachedCount) && preg_match('/\A\d+\z/D', $cachedCount) === 1) {
     $count = (int) $cachedCount;
 } else {
@@ -13,11 +13,11 @@ if (is_string($cachedCount) && preg_match('/\A\d+\z/D', $cachedCount) === 1) {
     try {
         $aboutConnection = openDatabaseConnection(2);
         $result = $aboutConnection->query(
-            'SELECT COUNT(*) AS clip_count FROM userurl WHERE expires_at > UTC_TIMESTAMP(6)'
+            'SELECT COALESCE(MAX(id), 0) AS clip_count FROM userurl'
         );
         $row = $result->fetch_assoc();
         $count = isset($row['clip_count']) ? (int) $row['clip_count'] : 0;
-        storeRedis('active-clip-count-v1', (string) $count, 300);
+        storeRedis('total-clip-count-v1', (string) $count, 300);
     } catch (Throwable $error) {
         error_log('About page clip count failed: ' . $error->getMessage());
     } finally {
@@ -99,7 +99,7 @@ if (is_string($cachedContributors)) {
                     </a>
                 </li>
                 <li>
-                    Active clips:
+                    Total clips made:
                     <?php echo $count === null ? 'unavailable' : escapeHtml((string) $count); ?>
                 </li>
             </ul>

--- a/tests/Unit/SecurityControlTest.php
+++ b/tests/Unit/SecurityControlTest.php
@@ -151,13 +151,15 @@ it('keeps shared navigation metadata from overwriting page variables', function 
         ->and($menu)->toContain('$releaseName');
 });
 
-it('keeps active clip totals and browser history aligned with the 48-hour lifetime', function () {
+it('keeps the historical clip total and browser history lifetime semantics', function () {
     $aboutPage = file_get_contents(dirname(__DIR__, 2) . '/public/about.php');
     $indexScript = file_get_contents(dirname(__DIR__, 2) . '/js/index.ts');
     $resultScript = file_get_contents(dirname(__DIR__, 2) . '/js/new.ts');
     $recentClips = file_get_contents(dirname(__DIR__, 2) . '/js/lib/recentClips.ts');
 
-    expect($aboutPage)->toContain('COUNT(*) AS clip_count FROM userurl WHERE expires_at > UTC_TIMESTAMP(6)')
+    expect($aboutPage)->toContain('SELECT COALESCE(MAX(id), 0) AS clip_count FROM userurl')
+        ->and($aboutPage)->toContain("getRedis('total-clip-count-v1')")
+        ->and($aboutPage)->toContain('Total clips made:')
         ->and($indexScript)->toContain('from "./lib/recentClips"')
         ->and($resultScript)->toContain('from "./lib/recentClips"')
         ->and($recentClips)->toContain('2 * 24 * 60 * 60 * 1000');


### PR DESCRIPTION
## Summary

- restore the About page’s historical `Total clips made` fact
- derive the value from the highest auto-incrementing `userurl.id`
- use a separate Redis cache key so the former active-count value cannot leak into the result
- update the regression coverage for the counter’s intended semantics

## Why

The security rollout changed this fact into a count of currently unexpired clips. The product’s original counter intentionally used the monotonically increasing clip row ID as a lightweight lifetime total.

The production `APP_RELEASE` value was also corrected separately from `security-hardening-2026-07-13` to the actual latest release tag, `v4.3.1`.

## Validation

- `vendor/bin/pest` — 50 tests, 282 assertions
- `git diff --check`
- production About page renders `Latest release: v4.3.1`
- production About page renders `Total clips made: 5237`
- production application-user query returns `MAX(userurl.id) = 5237`
