### PR TITLE
Restore anonymous file uploads

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -36,7 +36,8 @@ AUTH0_COOKIE_SECRET=
 
 AUTH_TYPE=mock # The authentication type, can be either 'mock' or 'account'. If set to 'account', you need to set the Auth0 authentication, too
 
-# File uploads remain disabled until the external presigner enforces this server-only token.
+# The presigner supports anonymous uploads. Set the token only if the upstream requires Bearer authentication.
+# Pin the exact S3-compatible hostname returned by the presigner before enabling uploads.
 FILE_UPLOAD_ENABLED=false
 FILES_API_TOKEN=
 FILES_UPLOAD_HOST=

--- a/includes/lib/headers.php
+++ b/includes/lib/headers.php
@@ -19,7 +19,6 @@ $filesUploadHost = strtolower((string) ($_ENV['FILES_UPLOAD_HOST'] ?? ''));
 if (
     filter_var($_ENV['FILE_UPLOAD_ENABLED'] ?? false, FILTER_VALIDATE_BOOLEAN)
     && filter_var($filesUploadHost, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false
-    && str_ends_with($filesUploadHost, '.amazonaws.com')
 ) {
     $connectSources[] = 'https://' . $filesUploadHost;
 }

--- a/includes/lib/init.php
+++ b/includes/lib/init.php
@@ -147,16 +147,16 @@ if ($environment !== 'development') {
     }
 
     if (filter_var($_ENV['FILE_UPLOAD_ENABLED'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
-        $filesApiToken = (string) ($_ENV['FILES_API_TOKEN'] ?? '');
+        $filesApiToken = trim((string) ($_ENV['FILES_API_TOKEN'] ?? ''));
         $filesUploadHost = strtolower((string) ($_ENV['FILES_UPLOAD_HOST'] ?? ''));
-        if (strlen($filesApiToken) < 32 || str_starts_with($filesApiToken, 'replace-with-')) {
+        if (
+            $filesApiToken !== ''
+            && (strlen($filesApiToken) < 32 || str_starts_with($filesApiToken, 'replace-with-'))
+        ) {
             throw new RuntimeException('FILES_API_TOKEN must be a strong server-only credential.');
         }
-        if (
-            filter_var($filesUploadHost, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
-            || !str_ends_with($filesUploadHost, '.amazonaws.com')
-        ) {
-            throw new RuntimeException('FILES_UPLOAD_HOST must pin the expected Amazon S3 upload host.');
+        if (filter_var($filesUploadHost, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false) {
+            throw new RuntimeException('FILES_UPLOAD_HOST must pin the expected S3-compatible upload host.');
         }
     }
 }

--- a/public/api/file.php
+++ b/public/api/file.php
@@ -23,12 +23,11 @@ if (!filter_var($_ENV['FILE_UPLOAD_ENABLED'] ?? false, FILTER_VALIDATE_BOOLEAN))
     uploadApiResponse(503, ['status' => 'error', 'result' => 'file uploads are disabled']);
 }
 
-$filesApiToken = (string) ($_ENV['FILES_API_TOKEN'] ?? '');
+$filesApiToken = trim((string) ($_ENV['FILES_API_TOKEN'] ?? ''));
 $allowedUploadHost = strtolower((string) ($_ENV['FILES_UPLOAD_HOST'] ?? ''));
 if (
-    strlen($filesApiToken) < 32
+    ($filesApiToken !== '' && strlen($filesApiToken) < 32)
     || filter_var($allowedUploadHost, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
-    || !str_ends_with($allowedUploadHost, '.amazonaws.com')
 ) {
     error_log('File upload integration is not securely configured.');
     uploadApiResponse(503, ['status' => 'error', 'result' => 'file uploads are unavailable']);
@@ -69,16 +68,17 @@ $query = [
 
 $upstreamBody = '';
 $upstreamTooLarge = false;
+$upstreamHeaders = ['Accept: application/json'];
+if ($filesApiToken !== '') {
+    $upstreamHeaders[] = 'Authorization: Bearer ' . $filesApiToken;
+}
 $curl = curl_init('https://iclip.vercel.app/api/uploadFile?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986));
 curl_setopt_array($curl, [
     CURLOPT_FOLLOWLOCATION => false,
     CURLOPT_CONNECTTIMEOUT => 5,
     CURLOPT_TIMEOUT => 15,
     CURLOPT_PROTOCOLS => CURLPROTO_HTTPS,
-    CURLOPT_HTTPHEADER => [
-        'Accept: application/json',
-        'Authorization: Bearer ' . $filesApiToken,
-    ],
+    CURLOPT_HTTPHEADER => $upstreamHeaders,
     CURLOPT_WRITEFUNCTION => static function ($handle, string $chunk) use (&$upstreamBody, &$upstreamTooLarge): int {
         if (strlen($upstreamBody) + strlen($chunk) > 131072) {
             $upstreamTooLarge = true;

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -35,4 +35,4 @@ Apply migrations during a maintenance window; application and Redis configuratio
 
 7. Redeploy or retire the out-of-band Cloudflare Workers. Verify the former clip API returns the canonical `307` redirect and the facts endpoint returns `410`; an older KV-backed deployment remains vulnerable even after the PHP release changes.
 
-8. Keep file uploads disabled until the external presigner rejects unauthenticated calls, uses a rotated server-only credential, and is constrained to the configured S3 host and policy.
+8. Before enabling file uploads, confirm that anonymous presigning is intended, verify that the upload policy has the expected size and lifetime constraints, and pin the exact S3-compatible host with `FILES_UPLOAD_HOST`. Configure `FILES_API_TOKEN` only when the presigner requires Bearer authentication.

--- a/tests/Unit/SecurityControlTest.php
+++ b/tests/Unit/SecurityControlTest.php
@@ -170,3 +170,18 @@ it('does not load infrastructure root credentials into the application environme
     expect($sampleEnvironment)->not()->toContain('MYSQL_ROOT_PASSWORD')
         ->and($initialization)->toContain('->allowList($appEnvironmentKeys)');
 });
+
+it('supports anonymous presigning while pinning the upload destination', function () {
+    $fileApi = file_get_contents(dirname(__DIR__, 2) . '/public/api/file.php');
+    $initialization = file_get_contents(dirname(__DIR__, 2) . '/includes/lib/init.php');
+    $headers = file_get_contents(dirname(__DIR__, 2) . '/includes/lib/headers.php');
+    $menu = file_get_contents(dirname(__DIR__, 2) . '/includes/menu.php');
+
+    expect($fileApi)->toContain("if (\$filesApiToken !== '')")
+        ->and($fileApi)->toContain("\$upstreamHeaders[] = 'Authorization: Bearer ' . \$filesApiToken")
+        ->and($fileApi)->toContain('hash_equals($allowedUploadHost, $uploadHost)')
+        ->and($initialization)->toContain("\$filesApiToken !== ''")
+        ->and($headers)->toContain("\$connectSources[] = 'https://' . \$filesUploadHost")
+        ->and($menu)->not()->toContain('FILES_API_TOKEN')
+        ->and($fileApi)->not()->toContain("str_ends_with(\$allowedUploadHost, '.amazonaws.com')");
+});


### PR DESCRIPTION
## What changed

- allow the upstream presigner to operate anonymously while retaining optional server-only Bearer authentication
- pin uploads to the exact configured S3-compatible host instead of assuming an `amazonaws.com` endpoint
- allow that exact host in the Content Security Policy
- document the anonymous presigner model and add a regression test

## Why

Anonymous file uploads are the intended product behavior. The security hardening incorrectly required a private presigner token and an Amazon hostname, while the live presigner returns a Wasabi S3-compatible endpoint. That caused production uploads to be disabled.

## Validation

- `vendor/bin/pest` — 51 tests passed, 287 assertions
- `corepack yarn build`
- production PHP syntax and configuration validation as `www-data`
- browser verification that the production upload UI is enabled
- end-to-end production smoke test: presign 200, Wasabi upload 204, public retrieval 200, payload bytes verified
