### PR TITLE
Exclude app scripts from Rocket Loader

### DIFF
--- a/includes/menu.php
+++ b/includes/menu.php
@@ -68,7 +68,7 @@
 
 </header>
 
-<script nonce="<?php echo htmlspecialchars(cspNonce(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+<script data-cfasync="false" nonce="<?php echo htmlspecialchars(cspNonce(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
   const loggedIn = <?php echo json_encode($user !== false) ?>;
   const isAdmin = <?php echo json_encode($isStaff) ?>;
   const version = <?php echo json_encode($releaseName ?? '') ?>;
@@ -78,4 +78,4 @@
   const csrfToken = <?php echo json_encode($menuCsrfToken) ?>;
 </script>
 
-<script src="<?php echo ROOT ?>/out/menu.js"></script>
+<script data-cfasync="false" src="<?php echo ROOT ?>/out/menu.js"></script>

--- a/public/admin.php
+++ b/public/admin.php
@@ -136,6 +136,6 @@ if ($isStaff) {
 <?php endif; ?>
 </main>
 </body>
-<script src="<?php echo ROOT; ?>/out/admin.js"></script>
+<script data-cfasync="false" src="<?php echo ROOT; ?>/out/admin.js"></script>
 
 </html>

--- a/public/core/get.php
+++ b/public/core/get.php
@@ -69,7 +69,7 @@ if ($user_code === '') {
       </div>
     </div>
   </div>
-  <script src="<?php echo ROOT ?>/out/get.js"></script>
+  <script data-cfasync="false" src="<?php echo ROOT ?>/out/get.js"></script>
 </body>
 
 </html>

--- a/public/core/set.php
+++ b/public/core/set.php
@@ -62,10 +62,10 @@ if ($url === null) {
               </span>
             </div>
             <canvas id="qrcode"></canvas>
-            <script nonce="<?php echo escapeHtml(cspNonce()) ?>">
+            <script data-cfasync="false" nonce="<?php echo escapeHtml(cspNonce()) ?>">
               const code = <?php echo json_encode($usr, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
             </script>
-            <script src="<?php echo ROOT ?>/out/new.js"></script>
+            <script data-cfasync="false" src="<?php echo ROOT ?>/out/new.js"></script>
           <?php else : ?>
             <p><span id="url" class="url"><?php echo escapeHtml($url) ?></span><br></p>
             <h1 class="mono"><?php echo escapeHtml($err) ?></h1>

--- a/public/file.php
+++ b/public/file.php
@@ -86,7 +86,7 @@
                 </dialog>
             </div>
 
-            <script src="<?php echo ROOT ?>/out/file.js"></script>
+            <script data-cfasync="false" src="<?php echo ROOT ?>/out/file.js"></script>
         <?php else : ?>
             <span id="content"> </span>
             <div class="title">

--- a/public/index.php
+++ b/public/index.php
@@ -72,10 +72,10 @@
         <div class="output"></div>
         </div>
     </main>
-    <script nonce="<?php echo htmlspecialchars(cspNonce(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+    <script data-cfasync="false" nonce="<?php echo htmlspecialchars(cspNonce(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
         const isMobile = <?php echo json_encode((bool) isMobile()) ?>;
     </script>
-    <script src="<?php echo ROOT ?>/out/index.js" defer> </script>
+    <script data-cfasync="false" src="<?php echo ROOT ?>/out/index.js" defer> </script>
 </body>
 
 </html>

--- a/public/receive.php
+++ b/public/receive.php
@@ -43,7 +43,7 @@
                         </div>
                     </div>
                 </form>
-                <script type="text/javascript" src="<?php echo ROOT ?>/out/receive.js"></script>
+                <script data-cfasync="false" type="text/javascript" src="<?php echo ROOT ?>/out/receive.js"></script>
             </div>
         </div>
     </main>

--- a/tests/Unit/SecurityControlTest.php
+++ b/tests/Unit/SecurityControlTest.php
@@ -187,3 +187,28 @@ it('supports anonymous presigning while pinning the upload destination', functio
         ->and($menu)->not()->toContain('FILES_API_TOKEN')
         ->and($fileApi)->not()->toContain("str_ends_with(\$allowedUploadHost, '.amazonaws.com')");
 });
+
+it('keeps application scripts out of Cloudflare Rocket Loader', function () {
+    $scriptFiles = [
+        'includes/menu.php',
+        'public/admin.php',
+        'public/core/get.php',
+        'public/core/set.php',
+        'public/file.php',
+        'public/index.php',
+        'public/receive.php',
+    ];
+
+    foreach ($scriptFiles as $scriptFile) {
+        $contents = file_get_contents(dirname(__DIR__, 2) . '/' . $scriptFile);
+        preg_match_all('/<script\\b[^>]*>/i', $contents, $scriptTags);
+
+        expect($scriptTags[0])->not()->toBeEmpty();
+        foreach ($scriptTags[0] as $scriptTag) {
+            expect($scriptTag)->toContain('data-cfasync="false"');
+            if (str_contains($scriptTag, ' src=')) {
+                expect(strpos($scriptTag, 'data-cfasync="false"'))->toBeLessThan(strpos($scriptTag, ' src='));
+            }
+        }
+    }
+});


### PR DESCRIPTION
## What changed

- opt every application script out of Cloudflare Rocket Loader with `data-cfasync="false"`
- keep the opt-out attribute before `src`, as required for external scripts
- add regression coverage for every PHP template that emits application JavaScript

## Why

Rocket Loader executes transformed inline scripts in a scope where their top-level bootstrap bindings are not visible to the bundled scripts. This caused `menu.js` and `file.js` to throw `ReferenceError: isAdmin is not defined`, breaking menu and upload-page initialization.

## Validation

- `vendor/bin/pest` — 52 tests passed, 313 assertions
- `corepack yarn build`
- PHP syntax checks for every touched template
- production browser verification: application scripts are no longer transformed, no console errors, upload UI initializes, and Settings opens successfully
