### PR TITLE
Reuse active clip codes

### DIFF
--- a/includes/components/get.php
+++ b/includes/components/get.php
@@ -50,7 +50,7 @@ function lookupClipUrl(string $code): ?string
             return null;
         }
 
-        $normalizedUrl = normalizeStoredClipUrl($row['url']);
+        $normalizedUrl = resolveStoredClipDestination($row['url']);
         $expiresAt = is_string($row['expires_at'])
             ? clipExpiryMicroseconds($row['expires_at'])
             : null;

--- a/includes/components/get.php
+++ b/includes/components/get.php
@@ -30,7 +30,8 @@ function lookupClipUrl(string $code): ?string
         $clipConnection = openDatabaseConnection();
         $statement = $clipConnection->prepare(
             'SELECT url, expires_at FROM userurl'
-            . ' WHERE usr = ? AND expires_at > UTC_TIMESTAMP(6)'
+            . ' WHERE usr = ?'
+            . ' AND (expires_at IS NULL OR expires_at > UTC_TIMESTAMP(6))'
             . ' ORDER BY id ASC LIMIT 1'
         );
         $statement->bind_param('s', $lookupCode);
@@ -41,20 +42,28 @@ function lookupClipUrl(string $code): ?string
 
         if (
             !is_array($row)
-            || !isset($row['url'], $row['expires_at'])
+            || !isset($row['url'])
+            || !array_key_exists('expires_at', $row)
             || !is_string($row['url'])
-            || !is_string($row['expires_at'])
+            || (!is_string($row['expires_at']) && $row['expires_at'] !== null)
         ) {
             return null;
         }
 
-        $normalizedUrl = normalizeClipUrl($row['url']);
-        $expiresAt = clipExpiryMicroseconds($row['expires_at']);
-        if ($normalizedUrl === null || $expiresAt === null) {
+        $normalizedUrl = normalizeStoredClipUrl($row['url']);
+        $expiresAt = is_string($row['expires_at'])
+            ? clipExpiryMicroseconds($row['expires_at'])
+            : null;
+        if (
+            $normalizedUrl === null
+            || (is_string($row['expires_at']) && $expiresAt === null)
+        ) {
             return null;
         }
 
-        storeClipRedis($lookupCode, $normalizedUrl, $expiresAt);
+        if ($expiresAt !== null) {
+            storeClipRedis($lookupCode, $normalizedUrl, $expiresAt);
+        }
 
         return $normalizedUrl;
     } catch (Throwable $exception) {

--- a/includes/components/new.php
+++ b/includes/components/new.php
@@ -113,6 +113,63 @@ function findActiveClipForUrl(mysqli $connection, string $normalizedUrl): ?array
 }
 
 /**
+ * Renew the oldest matching expired clip that is still awaiting cleanup.
+ *
+ * @param mysqli $connection Open application database connection.
+ * @param string $normalizedUrl Canonical absolute URI.
+ * @param string $createdAt UTC DATETIME(6) creation instant.
+ * @param string $expiresAt UTC DATETIME(6) expiration instant.
+ * @return string|null Renewed five-character clip code.
+ */
+function renewExpiredClipForUrl(
+    mysqli $connection,
+    string $normalizedUrl,
+    string $createdAt,
+    string $expiresAt
+): ?string {
+    $selectStatement = $connection->prepare(
+        'SELECT usr FROM userurl '
+        . 'WHERE BINARY url = BINARY ? '
+        . 'AND expires_at IS NOT NULL AND expires_at <= UTC_TIMESTAMP(6) '
+        . 'ORDER BY id ASC LIMIT 1'
+    );
+    try {
+        $selectStatement->bind_param('s', $normalizedUrl);
+        $selectStatement->execute();
+        $row = $selectStatement->get_result()->fetch_assoc();
+    } finally {
+        $selectStatement->close();
+    }
+
+    $code = is_array($row) && isset($row['usr']) && is_string($row['usr'])
+        ? normalizeClipCode($row['usr'])
+        : null;
+    if ($code === null) {
+        return null;
+    }
+
+    $updateStatement = $connection->prepare(
+        'UPDATE userurl SET date = ?, expires_at = ? '
+        . 'WHERE usr = ? AND BINARY url = BINARY ? '
+        . 'AND expires_at IS NOT NULL AND expires_at <= UTC_TIMESTAMP(6)'
+    );
+    try {
+        $updateStatement->bind_param(
+            'ssss',
+            $createdAt,
+            $expiresAt,
+            $code,
+            $normalizedUrl
+        );
+        $updateStatement->execute();
+
+        return $updateStatement->affected_rows === 1 ? $code : null;
+    } finally {
+        $updateStatement->close();
+    }
+}
+
+/**
  * Populate the optional Redis clip cache without failing the database write.
  *
  * @param string $code Five-character clip code.
@@ -134,7 +191,7 @@ function cacheClipDestination(string $code, string $normalizedUrl, ?int $expires
 }
 
 /**
- * Reuse an active clip for the same normalized URI or create a fresh code.
+ * Reuse or renew a clip for the same normalized URI before creating a code.
  *
  * @return array{0: string|null, 1: string}
  */
@@ -171,6 +228,18 @@ function createClip($url): array
         $expiration = clipExpirationDateTime($createdAt);
         $expirationForDatabase = $expiration->format('Y-m-d H:i:s.u');
         $expiresAt = dateTimeUnixMicroseconds($expiration);
+
+        $renewedCode = renewExpiredClipForUrl(
+            $connection,
+            $normalizedUrl,
+            $createdForDatabase,
+            $expirationForDatabase
+        );
+        if ($renewedCode !== null) {
+            cacheClipDestination($renewedCode, $normalizedUrl, $expiresAt);
+
+            return [$renewedCode, ''];
+        }
 
         for ($attempt = 0; $attempt < CLIP_INSERT_RETRIES; $attempt++) {
             $code = generateClipCode();

--- a/includes/components/new.php
+++ b/includes/components/new.php
@@ -6,10 +6,122 @@ include_once __DIR__ . '/../lib/database.php';
 include_once __DIR__ . '/../lib/security.php';
 
 const CLIP_INSERT_RETRIES = 10;
+const CLIP_URI_LOCK_TIMEOUT_SECONDS = 5;
 const CLIP_CREATE_ERROR = 'Unable to save clip. Please try again later.';
 
 /**
- * Create a clip with a fresh capability code.
+ * Return a bounded MySQL advisory-lock name for one normalized URI.
+ *
+ * @param string $normalizedUrl Canonical absolute URI.
+ * @return string
+ */
+function clipUriLockName(string $normalizedUrl): string
+{
+    $digest = base64_encode(hash('sha256', $normalizedUrl, true));
+    $digest = rtrim(strtr($digest, '+/', '-_'), '=');
+
+    return 'interclip:clip:' . $digest;
+}
+
+/**
+ * Acquire the database-wide lock that serializes creation for one URI.
+ *
+ * @param mysqli $connection Open application database connection.
+ * @param string $normalizedUrl Canonical absolute URI.
+ * @return string Acquired advisory-lock name.
+ */
+function acquireClipUriLock(mysqli $connection, string $normalizedUrl): string
+{
+    $lockName = clipUriLockName($normalizedUrl);
+    $statement = $connection->prepare('SELECT GET_LOCK(?, ?) AS acquired');
+    try {
+        $timeout = CLIP_URI_LOCK_TIMEOUT_SECONDS;
+        $statement->bind_param('si', $lockName, $timeout);
+        $statement->execute();
+        $row = $statement->get_result()->fetch_assoc();
+        if ((int) ($row['acquired'] ?? 0) !== 1) {
+            throw new RuntimeException('Timed out waiting for the clip URI lock');
+        }
+    } finally {
+        $statement->close();
+    }
+
+    return $lockName;
+}
+
+/**
+ * Release a previously acquired URI advisory lock.
+ *
+ * @param mysqli $connection Open application database connection.
+ * @param string $lockName Acquired advisory-lock name.
+ * @return void
+ */
+function releaseClipUriLock(mysqli $connection, string $lockName): void
+{
+    $statement = $connection->prepare('SELECT RELEASE_LOCK(?)');
+    try {
+        $statement->bind_param('s', $lockName);
+        $statement->execute();
+    } finally {
+        $statement->close();
+    }
+}
+
+/**
+ * Find the first unexpired code whose URI exactly matches the input.
+ *
+ * @param mysqli $connection Open application database connection.
+ * @param string $normalizedUrl Canonical absolute URI.
+ * @return array{0: string, 1: int}|null
+ */
+function findActiveClipForUrl(mysqli $connection, string $normalizedUrl): ?array
+{
+    $statement = $connection->prepare(
+        'SELECT usr, expires_at FROM userurl '
+        . 'WHERE BINARY url = BINARY ? AND expires_at > UTC_TIMESTAMP(6) '
+        . 'ORDER BY id ASC LIMIT 1'
+    );
+    try {
+        $statement->bind_param('s', $normalizedUrl);
+        $statement->execute();
+        $row = $statement->get_result()->fetch_assoc();
+    } finally {
+        $statement->close();
+    }
+
+    if (!is_array($row)) {
+        return null;
+    }
+
+    $code = isset($row['usr']) && is_string($row['usr'])
+        ? normalizeClipCode($row['usr'])
+        : null;
+    $expiresAt = isset($row['expires_at']) && is_string($row['expires_at'])
+        ? clipExpiryMicroseconds($row['expires_at'])
+        : null;
+
+    return $code !== null && $expiresAt !== null ? [$code, $expiresAt] : null;
+}
+
+/**
+ * Populate the optional Redis clip cache without failing the database write.
+ *
+ * @param string $code Five-character clip code.
+ * @param string $normalizedUrl Canonical absolute URI.
+ * @param int $expiresAt Exact expiration instant in Unix microseconds.
+ * @return void
+ */
+function cacheClipDestination(string $code, string $normalizedUrl, int $expiresAt): void
+{
+    try {
+        storeClipRedis($code, $normalizedUrl, $expiresAt);
+    } catch (Throwable $exception) {
+        error_log('Clip cache population failed: ' . $exception->getMessage());
+    }
+}
+
+/**
+ * Reuse an active clip for the same normalized URI or create a fresh code.
  *
  * @return array{0: string|null, 1: string}
  */
@@ -27,9 +139,20 @@ function createClip($url): array
     }
 
     $connection = null;
+    $lockName = null;
 
     try {
         $connection = openDatabaseConnection();
+        $lockName = acquireClipUriLock($connection, $normalizedUrl);
+
+        $existingClip = findActiveClipForUrl($connection, $normalizedUrl);
+        if ($existingClip !== null) {
+            [$code, $expiresAt] = $existingClip;
+            cacheClipDestination($code, $normalizedUrl, $expiresAt);
+
+            return [$code, ''];
+        }
+
         $createdAt = new DateTimeImmutable('now', new DateTimeZone('UTC'));
         $createdForDatabase = $createdAt->format('Y-m-d H:i:s.u');
         $expiration = clipExpirationDateTime($createdAt);
@@ -54,11 +177,7 @@ function createClip($url): array
                 );
                 $statement->execute();
 
-                try {
-                    storeClipRedis($code, $normalizedUrl, $expiresAt);
-                } catch (Throwable $exception) {
-                    error_log('Clip cache population failed: ' . $exception->getMessage());
-                }
+                cacheClipDestination($code, $normalizedUrl, $expiresAt);
 
                 return [$code, ''];
             } catch (mysqli_sql_exception $exception) {
@@ -81,6 +200,15 @@ function createClip($url): array
         return [null, CLIP_CREATE_ERROR];
     } finally {
         if ($connection instanceof mysqli) {
+            if ($lockName !== null) {
+                try {
+                    releaseClipUriLock($connection, $lockName);
+                } catch (Throwable $exception) {
+                    error_log(
+                        'Clip URI lock release failed: ' . $exception->getMessage()
+                    );
+                }
+            }
             $connection->close();
         }
     }

--- a/includes/components/new.php
+++ b/includes/components/new.php
@@ -72,13 +72,14 @@ function releaseClipUriLock(mysqli $connection, string $lockName): void
  *
  * @param mysqli $connection Open application database connection.
  * @param string $normalizedUrl Canonical absolute URI.
- * @return array{0: string, 1: int}|null
+ * @return array{0: string, 1: int|null}|null
  */
 function findActiveClipForUrl(mysqli $connection, string $normalizedUrl): ?array
 {
     $statement = $connection->prepare(
         'SELECT usr, expires_at FROM userurl '
-        . 'WHERE BINARY url = BINARY ? AND expires_at > UTC_TIMESTAMP(6) '
+        . 'WHERE BINARY url = BINARY ? '
+        . 'AND (expires_at IS NULL OR expires_at > UTC_TIMESTAMP(6)) '
         . 'ORDER BY id ASC LIMIT 1'
     );
     try {
@@ -96,11 +97,19 @@ function findActiveClipForUrl(mysqli $connection, string $normalizedUrl): ?array
     $code = isset($row['usr']) && is_string($row['usr'])
         ? normalizeClipCode($row['usr'])
         : null;
-    $expiresAt = isset($row['expires_at']) && is_string($row['expires_at'])
+    if (!array_key_exists('expires_at', $row)) {
+        return null;
+    }
+
+    $expiresAt = is_string($row['expires_at'])
         ? clipExpiryMicroseconds($row['expires_at'])
         : null;
 
-    return $code !== null && $expiresAt !== null ? [$code, $expiresAt] : null;
+    if ($row['expires_at'] !== null && $expiresAt === null) {
+        return null;
+    }
+
+    return $code !== null ? [$code, $expiresAt] : null;
 }
 
 /**
@@ -108,11 +117,15 @@ function findActiveClipForUrl(mysqli $connection, string $normalizedUrl): ?array
  *
  * @param string $code Five-character clip code.
  * @param string $normalizedUrl Canonical absolute URI.
- * @param int $expiresAt Exact expiration instant in Unix microseconds.
+ * @param int|null $expiresAt Exact expiration instant in Unix microseconds.
  * @return void
  */
-function cacheClipDestination(string $code, string $normalizedUrl, int $expiresAt): void
+function cacheClipDestination(string $code, string $normalizedUrl, ?int $expiresAt): void
 {
+    if ($expiresAt === null) {
+        return;
+    }
+
     try {
         storeClipRedis($code, $normalizedUrl, $expiresAt);
     } catch (Throwable $exception) {

--- a/includes/lib/functions.php
+++ b/includes/lib/functions.php
@@ -35,19 +35,20 @@ if (!function_exists('str_starts_with')) {
  */
 function reDir($url)
 {
-    if (!is_string($url) || normalizeStoredClipUrl($url) === null) {
+    $destination = is_string($url) ? resolveStoredClipDestination($url) : null;
+    if ($destination === null) {
         http_response_code(400);
         exit('Invalid redirect destination.');
     }
 
     header('X-Robots-Tag: noindex, nofollow, noarchive');
-    if (!isSafeNavigationUri($url)) {
+    if (!isSafeNavigationUri($destination)) {
         header('Content-Type: text/plain; charset=UTF-8');
-        echo $url;
+        echo $destination;
         exit;
     }
 
-    header('Location: ' . $url, true, 302);
+    header('Location: ' . $destination, true, 302);
     exit;
 }
 

--- a/includes/lib/functions.php
+++ b/includes/lib/functions.php
@@ -35,7 +35,7 @@ if (!function_exists('str_starts_with')) {
  */
 function reDir($url)
 {
-    if (!is_string($url) || normalizeClipUrl($url) === null) {
+    if (!is_string($url) || normalizeStoredClipUrl($url) === null) {
         http_response_code(400);
         exit('Invalid redirect destination.');
     }

--- a/includes/lib/security.php
+++ b/includes/lib/security.php
@@ -4,6 +4,7 @@ use League\Uri\Contracts\UriException;
 use League\Uri\Uri;
 
 const CLIP_URL_MAX_LENGTH = 2048;
+const CLIP_STORED_URL_MAX_LENGTH = 65_535;
 const CLIP_CODE_LENGTH = 5;
 const CLIP_CODE_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
 const CLIP_RESERVED_CODES = ['admin', 'about', 'login', 'tests'];
@@ -12,9 +13,9 @@ const CLIP_TTL_SECONDS = 2 * 24 * 60 * 60;
 /**
  * Let League URI validate and canonicalize an absolute URI.
  */
-function validatedClipUri(string $uri): ?Uri
+function validatedClipUri(string $uri, int $maximumLength = CLIP_URL_MAX_LENGTH): ?Uri
 {
-    if ($uri === '' || strlen($uri) > CLIP_URL_MAX_LENGTH) {
+    if ($uri === '' || strlen($uri) > $maximumLength) {
         return null;
     }
 
@@ -24,7 +25,7 @@ function validatedClipUri(string $uri): ?Uri
         return null;
     }
 
-    return $validated->isAbsolute() && strlen($validated->toString()) <= CLIP_URL_MAX_LENGTH
+    return $validated->isAbsolute() && strlen($validated->toString()) <= $maximumLength
         ? $validated
         : null;
 }
@@ -35,6 +36,14 @@ function validatedClipUri(string $uri): ?Uri
 function normalizeClipUrl(string $url): ?string
 {
     return validatedClipUri($url)?->toString();
+}
+
+/**
+ * Validate stored legacy destinations without expanding the public input limit.
+ */
+function normalizeStoredClipUrl(string $url): ?string
+{
+    return validatedClipUri($url, CLIP_STORED_URL_MAX_LENGTH)?->toString();
 }
 
 /**

--- a/includes/lib/security.php
+++ b/includes/lib/security.php
@@ -47,6 +47,18 @@ function normalizeStoredClipUrl(string $url): ?string
 }
 
 /**
+ * Return a bounded stored destination, keeping malformed legacy values inert.
+ */
+function resolveStoredClipDestination(string $value): ?string
+{
+    if ($value === '' || strlen($value) > CLIP_STORED_URL_MAX_LENGTH) {
+        return null;
+    }
+
+    return normalizeStoredClipUrl($value) ?? $value;
+}
+
+/**
  * Executable URI schemes are valid clipboard contents but must not become
  * active links or redirects from the Interclip origin.
  */

--- a/scripts/db.sql
+++ b/scripts/db.sql
@@ -6,9 +6,9 @@ DROP TABLE IF EXISTS `clip_metrics`;
 CREATE TABLE `userurl` (
   `id` int NOT NULL AUTO_INCREMENT,
   `usr` char(5) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
-  `url` varchar(2048) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `date` text CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `expires_at` datetime(6) NOT NULL,
+  `expires_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `userurl_usr_unique` (`usr`),
   KEY `userurl_expires_at` (`expires_at`),
@@ -29,4 +29,4 @@ CREATE TABLE `accounts` (
 ### Setting up MySQL cron jobs
 /* Delete expired clips (runs every hour) */
 DROP EVENT IF EXISTS `clean_expired`;
-CREATE EVENT `clean_expired` ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE ENABLE DO DELETE FROM userurl WHERE expires_at <= UTC_TIMESTAMP(6);
+CREATE EVENT `clean_expired` ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE ENABLE DO DELETE FROM userurl WHERE expires_at IS NOT NULL AND expires_at <= UTC_TIMESTAMP(6);

--- a/scripts/migrations/2026-07-11-security-hardening.sql
+++ b/scripts/migrations/2026-07-11-security-hardening.sql
@@ -22,14 +22,6 @@ BEGIN
       SET MESSAGE_TEXT = 'Duplicate clip codes must be resolved before migration';
   END IF;
 
-  IF EXISTS (
-    SELECT 1
-    FROM `userurl`
-    WHERE `expires` IS NULL OR OCTET_LENGTH(`url`) > 2048
-  ) THEN
-    SIGNAL SQLSTATE '45000'
-      SET MESSAGE_TEXT = 'Missing expirations or oversized URLs must be resolved before migration';
-  END IF;
 END//
 DELIMITER ;
 
@@ -42,15 +34,18 @@ ALTER TABLE `userurl`
   ADD COLUMN `expires_at` datetime(6) NULL AFTER `expires`;
 
 UPDATE `userurl`
-SET `expires_at` = LEAST(
-  CAST(CONCAT(`expires`, ' 23:59:59.999999') AS DATETIME(6)),
-  UTC_TIMESTAMP(6) + INTERVAL 48 HOUR
-);
+SET `expires_at` = CASE
+  WHEN `expires` IS NULL THEN NULL
+  ELSE LEAST(
+    CAST(CONCAT(`expires`, ' 23:59:59.999999') AS DATETIME(6)),
+    UTC_TIMESTAMP(6) + INTERVAL 48 HOUR
+  )
+END;
 
 ALTER TABLE `userurl`
   MODIFY `usr` char(5) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
-  MODIFY `url` varchar(2048) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  MODIFY `expires_at` datetime(6) NOT NULL,
+  MODIFY `url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  MODIFY `expires_at` datetime(6) NULL,
   DROP COLUMN `expires`,
   ADD UNIQUE KEY `userurl_usr_unique` (`usr`),
   ADD KEY `userurl_expires_at` (`expires_at`),
@@ -68,4 +63,5 @@ DROP EVENT IF EXISTS `clean_expired`;
 CREATE EVENT `clean_expired`
   ON SCHEDULE EVERY 1 HOUR
   ON COMPLETION PRESERVE ENABLE
-  DO DELETE FROM `userurl` WHERE `expires_at` <= UTC_TIMESTAMP(6);
+  DO DELETE FROM `userurl`
+    WHERE `expires_at` IS NOT NULL AND `expires_at` <= UTC_TIMESTAMP(6);

--- a/scripts/migrations/2026-07-14-preserve-permanent-clips.sql
+++ b/scripts/migrations/2026-07-14-preserve-permanent-clips.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `userurl`
+  MODIFY `url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  MODIFY `expires_at` datetime(6) NULL;
+
+DROP EVENT IF EXISTS `clean_expired`;
+CREATE EVENT `clean_expired`
+  ON SCHEDULE EVERY 1 HOUR
+  ON COMPLETION PRESERVE ENABLE
+  DO DELETE FROM `userurl`
+    WHERE `expires_at` IS NOT NULL AND `expires_at` <= UTC_TIMESTAMP(6);

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -10,8 +10,17 @@ Apply migrations during a maintenance window; application and Redis configuratio
    mysql --database="$DB_NAME" < scripts/migrations/2026-07-11-security-hardening.sql
    ```
 
-   The migration caps legacy destination lifetimes at 48 hours from the
-   migration, while preserving any earlier existing expiry.
+   The migration caps expiring legacy destination lifetimes at 48 hours from
+   the migration, while preserving any earlier existing expiry. A legacy
+   `NULL` expiry remains `NULL` and represents a permanent clip.
+
+   Databases that already ran the original hardening migration must then apply
+   `2026-07-14-preserve-permanent-clips.sql` before restoring any permanent
+   rows from the pre-migration backup:
+
+   ```sh
+   mysql --database="$DB_NAME" < scripts/migrations/2026-07-14-preserve-permanent-clips.sql
+   ```
 
 4. List staff rows and assign each legitimate account its verified Auth0 `sub` by primary key. Never infer staff identity from email alone.
 
@@ -25,7 +34,9 @@ Apply migrations during a maintenance window; application and Redis configuratio
 
    The final query must return no legitimate staff accounts before application activation. Remove the old mock row only after confirming it is not a real account.
 
-5. Verify MySQL's event scheduler is enabled so expired destinations are deleted:
+5. Verify MySQL's event scheduler is enabled so expired destinations are
+   deleted. The cleanup event excludes permanent clips whose `expires_at` is
+   `NULL`:
 
    ```sql
    SHOW VARIABLES LIKE 'event_scheduler';

--- a/tests/Unit/ClipBoundaryTest.php
+++ b/tests/Unit/ClipBoundaryTest.php
@@ -27,3 +27,12 @@ it('does not treat arbitrary cache keys as clip codes', function () {
         $GLOBALS['redisAvailable'] = $previousAvailability;
     }
 });
+
+it('derives bounded distinct database locks from normalized URIs', function () {
+    $firstLock = clipUriLockName('https://example.com/path');
+    $secondLock = clipUriLockName('https://example.com/Path');
+
+    expect($firstLock)->toStartWith('interclip:clip:')
+        ->and(strlen($firstLock))->toBeLessThanOrEqual(64)
+        ->and($secondLock)->not()->toBe($firstLock);
+});

--- a/tests/Unit/DatabaseSchemaSecurityTest.php
+++ b/tests/Unit/DatabaseSchemaSecurityTest.php
@@ -5,7 +5,10 @@ it('enforces unique case-insensitive clip codes in the schema', function () {
 
     expect($schema)->toContain('`usr` char(5) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL')
         ->and($schema)->toContain('UNIQUE KEY `userurl_usr_unique` (`usr`)')
-        ->and($schema)->toContain('`expires_at` datetime(6) NOT NULL')
+        ->and($schema)->toContain(
+            '`url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL'
+        )
+        ->and($schema)->toContain('`expires_at` datetime(6) DEFAULT NULL')
         ->and($schema)->toContain('CHECK (`usr` REGEXP \'^[A-Za-z0-9]{5}$\'')
         ->and($schema)->toContain("LOWER(`usr`) NOT IN ('admin', 'about', 'login', 'tests')");
 });
@@ -15,7 +18,9 @@ it('returns expired short codes to the reusable pool', function () {
 
     expect($schema)->not()->toContain('CREATE TABLE `issued_clip_codes`')
         ->and($schema)->not()->toContain('FOREIGN KEY (`usr`) REFERENCES `issued_clip_codes` (`usr`)')
-        ->and($schema)->toContain('DELETE FROM userurl WHERE expires_at <= UTC_TIMESTAMP(6)');
+        ->and($schema)->toContain(
+            'DELETE FROM userurl WHERE expires_at IS NOT NULL AND expires_at <= UTC_TIMESTAMP(6)'
+        );
 });
 
 it('does not maintain a separate lifetime issuance metric', function () {
@@ -54,8 +59,24 @@ it('ships a preflighted migration for existing databases', function () {
         ->and($migration)->toContain('Invalid clip codes must be resolved before migration')
         ->and($migration)->not()->toContain('CREATE TABLE `issued_clip_codes`')
         ->and($migration)->toContain('UTC_TIMESTAMP(6) + INTERVAL 48 HOUR')
+        ->and($migration)->toContain('WHEN `expires` IS NULL THEN NULL')
+        ->and($migration)->toContain('MODIFY `expires_at` datetime(6) NULL')
         ->and($migration)->toContain('DROP COLUMN `expires`')
         ->and($migration)->toContain('ALTER TABLE `accounts`')
         ->and($migration)->toContain('ADD COLUMN `subject`')
         ->and($migration)->not()->toContain('DELETE FROM `accounts`');
+});
+
+it('ships a migration that preserves permanent clips', function () {
+    $migration = file_get_contents(
+        dirname(__DIR__, 2) . '/scripts/migrations/2026-07-14-preserve-permanent-clips.sql'
+    );
+
+    expect($migration)->toContain('MODIFY `expires_at` datetime(6) NULL')
+        ->and($migration)->toContain(
+            'MODIFY `url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL'
+        )
+        ->and($migration)->toContain(
+            'WHERE `expires_at` IS NOT NULL AND `expires_at` <= UTC_TIMESTAMP(6)'
+        );
 });

--- a/tests/Unit/SecurityControlTest.php
+++ b/tests/Unit/SecurityControlTest.php
@@ -61,6 +61,18 @@ it('reuses an active clip code for the same normalized URI', function () {
         ->toBeLessThan(strpos($clipCreation, 'INSERT INTO userurl'));
 });
 
+it('renews a matching expired clip before allocating a new code', function () {
+    $clipCreation = file_get_contents(dirname(__DIR__, 2) . '/includes/components/new.php');
+
+    expect($clipCreation)->toContain('renewExpiredClipForUrl')
+        ->and($clipCreation)->toContain(
+            'AND expires_at IS NOT NULL AND expires_at <= UTC_TIMESTAMP(6)'
+        )
+        ->and($clipCreation)->toContain('$updateStatement->affected_rows === 1')
+        ->and(strpos($clipCreation, '$renewedCode = renewExpiredClipForUrl'))
+        ->toBeLessThan(strpos($clipCreation, 'INSERT INTO userurl'));
+});
+
 it('shares strict database connection setup across application paths', function () {
     $database = file_get_contents(dirname(__DIR__, 2) . '/includes/lib/database.php');
 

--- a/tests/Unit/SecurityControlTest.php
+++ b/tests/Unit/SecurityControlTest.php
@@ -41,11 +41,16 @@ it('performs direct clip lookup only in the front controller', function () {
         ->and($errorPage)->not()->toContain('includes/components/get.php');
 });
 
-it('does not reuse bearer codes based on URL equality', function () {
+it('reuses an active clip code for the same normalized URI', function () {
     $clipCreation = file_get_contents(dirname(__DIR__, 2) . '/includes/components/new.php');
 
-    expect($clipCreation)->not()->toContain('WHERE url = ?')
-        ->and($clipCreation)->not()->toContain('findActiveClipForUrl');
+    expect($clipCreation)->toContain('findActiveClipForUrl')
+        ->and($clipCreation)->toContain('WHERE BINARY url = BINARY ? AND expires_at > UTC_TIMESTAMP(6)')
+        ->and($clipCreation)->toContain('SELECT GET_LOCK(?, ?) AS acquired')
+        ->and(strpos($clipCreation, 'acquireClipUriLock($connection, $normalizedUrl)'))
+        ->toBeLessThan(strpos($clipCreation, '$existingClip = findActiveClipForUrl'))
+        ->and(strpos($clipCreation, '$existingClip = findActiveClipForUrl'))
+        ->toBeLessThan(strpos($clipCreation, 'INSERT INTO userurl'));
 });
 
 it('shares strict database connection setup across application paths', function () {

--- a/tests/Unit/SecurityControlTest.php
+++ b/tests/Unit/SecurityControlTest.php
@@ -43,9 +43,17 @@ it('performs direct clip lookup only in the front controller', function () {
 
 it('reuses an active clip code for the same normalized URI', function () {
     $clipCreation = file_get_contents(dirname(__DIR__, 2) . '/includes/components/new.php');
+    $clipLookup = file_get_contents(dirname(__DIR__, 2) . '/includes/components/get.php');
 
     expect($clipCreation)->toContain('findActiveClipForUrl')
-        ->and($clipCreation)->toContain('WHERE BINARY url = BINARY ? AND expires_at > UTC_TIMESTAMP(6)')
+        ->and($clipCreation)->toContain(
+            'AND (expires_at IS NULL OR expires_at > UTC_TIMESTAMP(6))'
+        )
+        ->and($clipLookup)->toContain(
+            'AND (expires_at IS NULL OR expires_at > UTC_TIMESTAMP(6))'
+        )
+        ->and($clipCreation)->toContain('if ($expiresAt === null)')
+        ->and($clipLookup)->toContain('if ($expiresAt !== null)')
         ->and($clipCreation)->toContain('SELECT GET_LOCK(?, ?) AS acquired')
         ->and(strpos($clipCreation, 'acquireClipUriLock($connection, $normalizedUrl)'))
         ->toBeLessThan(strpos($clipCreation, '$existingClip = findActiveClipForUrl'))

--- a/tests/Unit/SecurityTest.php
+++ b/tests/Unit/SecurityTest.php
@@ -73,6 +73,15 @@ it('enforces the clip URL length boundary without truncating', function () {
         ->and(normalizeClipUrl($expandsPastStorageLimit))->toBeNull();
 });
 
+it('accepts longer legacy destinations only at the storage boundary', function () {
+    $legacyUrl = 'custom:' . str_repeat('a', CLIP_URL_MAX_LENGTH);
+    $tooLarge = 'custom:' . str_repeat('a', CLIP_STORED_URL_MAX_LENGTH);
+
+    expect(normalizeClipUrl($legacyUrl))->toBeNull()
+        ->and(normalizeStoredClipUrl($legacyUrl))->toBe($legacyUrl)
+        ->and(normalizeStoredClipUrl($tooLarge))->toBeNull();
+});
+
 it('accepts five-character alphanumeric clip codes only', function () {
     expect(isValidClipCode('aB123'))->toBeTrue()
         ->and(normalizeClipCode('aB123'))->toBe('ab123')

--- a/tests/Unit/SecurityTest.php
+++ b/tests/Unit/SecurityTest.php
@@ -82,6 +82,17 @@ it('accepts longer legacy destinations only at the storage boundary', function (
         ->and(normalizeStoredClipUrl($tooLarge))->toBeNull();
 });
 
+it('returns malformed legacy destinations as inert stored text', function () {
+    $relativeValue = '/legacy/relative-value';
+    $malformedValue = 'http://[legacy-value';
+
+    expect(resolveStoredClipDestination($relativeValue))->toBe($relativeValue)
+        ->and(resolveStoredClipDestination($malformedValue))->toBe($malformedValue)
+        ->and(isSafeNavigationUri($relativeValue))->toBeFalse()
+        ->and(isSafeNavigationUri($malformedValue))->toBeFalse()
+        ->and(resolveStoredClipDestination(''))->toBeNull();
+});
+
 it('accepts five-character alphanumeric clip codes only', function () {
     expect(isValidClipCode('aB123'))->toBeTrue()
         ->and(normalizeClipCode('aB123'))->toBe('ab123')


### PR DESCRIPTION
## What changed

- look up an exact normalized URI before generating a new clip code
- return the existing code only while that clip remains unexpired
- serialize creation for each normalized URI with a bounded MySQL advisory lock, preventing concurrent requests from minting duplicates
- preserve code recycling after expiry and repopulate Redis for reused clips

## Why

Active clips for the same URI are expected to reuse their existing five-character code. The security hardening incorrectly removed that product behavior and added a regression assertion forbidding reuse.

## Validation

- `vendor/bin/pest` — 53 tests passed, 321 assertions
- PHP syntax validation
- production integration: two concurrent requests and one sequential request returned the same five-character code
- database verification: one active row and one distinct code for the smoke-test URI
